### PR TITLE
Add support for multiple entry paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
       - name: example-script
         path: "/var/log/example-script/*.log"
         postrotate: killall -HUP some_process_name
+      - name: example-multipath
+        path:
+          - "/var/log/example-multipath-one/*.log"
+          - "/var/log/example-multipath-two/*.log"
       - name: btmp
         path: /var/log/btmp
         missingok: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -32,6 +32,10 @@
       - name: example-script
         path: "/var/log/example-script/*.log"
         postrotate: killall -HUP some_process_name
+      - name: example-multipath
+        path:
+          - "/var/log/example-multipath-one/*.log"
+          - "/var/log/example-multipath-two/*.log"
       - name: btmp
         path: /var/log/btmp
         missingok: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -25,6 +25,8 @@
         - /var/log/example-script
         - /var/log/example-sharedscripts
         - /var/log/example-dateyesterday
+        - /var/log/example-multipath-one
+        - /var/log/example-multipath-two
 
     - name: Create log file
       ansible.builtin.copy:
@@ -42,6 +44,8 @@
         - /var/log/example-script/app.log
         - /var/log/example-sharedscripts/app.log
         - /var/log/example-dateyesterday/app.log
+        - /var/log/example-multipath-one/app.log
+        - /var/log/example-multipath-two/app.log
         - /var/log/btmp
         - /var/log/wtmp
         - /var/log/hawkey.log

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -59,7 +59,10 @@
       - item.name is string
       - item.name is not none
       - item.path is defined
-      - item.path is string
+      - item.path is string or
+        (item.path is iterable and
+        item.path is not string and
+        item.path is not mapping)
       - item.path is not none
     quiet: true
   loop: "{{ logrotate_entries }}"

--- a/templates/entry.j2
+++ b/templates/entry.j2
@@ -1,7 +1,12 @@
 {{ ansible_managed | comment }}
 
+{% if item.path is iterable and item.path is not string and item.path is not mapping %}
+{% for path in item.path %}
+{{ path }}{{ " {" if loop.last }}
+{% endfor %}
+{% else %}
 {{ item.path }} {
-
+{% endif %}
 {% if item.frequency is defined %}    {{ item.frequency }}{% endif %}
 
 {% if item.compress is defined and item.compress %}    compress{% endif %}


### PR DESCRIPTION
Provides the ability to specify multiple paths, as an alternative to specifying a single path, for a piece of logrotate configuration.